### PR TITLE
Postgres Deployment and Automatic data dump import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,140 @@
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+.idea

--- a/specs/postgres/README.md
+++ b/specs/postgres/README.md
@@ -1,0 +1,13 @@
+# Deploy Postgres and Import data from backup
+
+The [setup-postgres.sh](./setup-postgres.sh) deploys a postgres instance using [specs](./base) and configurable storage
+class and storage size. The script can also download the backup file from AWS S3 or use local file and import the data dump into a given database.
+
+### Usage
+
+```shell
+bash setup-postgres.sh <STORAGE_CLASS TO USE> \
+ <SIZE OF STORAGE TO PROVISION> <NAMESPACE TO DEPLOY POSTGRES> \
+ '<LOCAL_OR_S3_PATH>' \
+ <DATABASE TO CREATE AND DUMP DATA> <PG_PASSWORD>
+```

--- a/specs/postgres/README.md
+++ b/specs/postgres/README.md
@@ -11,3 +11,6 @@ bash setup-postgres.sh <STORAGE_CLASS TO USE> \
  '<LOCAL_OR_S3_PATH>' \
  <DATABASE TO CREATE AND DUMP DATA> <PG_PASSWORD>
 ```
+
+For S3 files the path format is `s3://<bucket>/<path>` and for local files it's POSIX style path.
+We only support importing from `.gz` compressed files. These files must contain only one SQL file.

--- a/specs/postgres/base/deployment.yaml
+++ b/specs/postgres/base/deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lb-postgres
+  labels:
+    app: lb-postgres
+spec:
+  selector:
+    matchLabels:
+      app: lb-postgres
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: lb-postgres
+    spec:
+      containers:
+      - name: lb-postgres
+        image: postgres:11-bullseye
+        imagePullPolicy: "IfNotPresent"
+        ports:
+        - containerPort: 5432
+          name: lb-postgres
+        env:
+        - name: POSTGRES_USER
+          value: pgbench
+        - name: POSTGRES_PASSWORD
+          value: superpostgres
+        - name: PGBENCH_PASSWORD
+          value: superpostgres
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
+        livenessProbe:
+          initialDelaySeconds: 5
+          periodSeconds: 15
+          failureThreshold: 3
+          tcpSocket:
+            port: 5432
+        readinessProbe:
+          initialDelaySeconds: 5
+          periodSeconds: 15
+          failureThreshold: 3
+          tcpSocket:
+            port: 5432
+        volumeMounts:
+        - mountPath: /var/lib/postgresql/data
+          name: postgredb
+      volumes:
+      - name: postgredb
+        persistentVolumeClaim:
+          claimName: lb-postgres-data
+

--- a/specs/postgres/base/deployment.yaml
+++ b/specs/postgres/base/deployment.yaml
@@ -26,13 +26,12 @@ spec:
         ports:
         - containerPort: 5432
           name: lb-postgres
+        envFrom:
+          - secretRef:
+              name: lb-postgres-secret
         env:
         - name: POSTGRES_USER
-          value: pgbench
-        - name: POSTGRES_PASSWORD
-          value: superpostgres
-        - name: PGBENCH_PASSWORD
-          value: superpostgres
+          value: postgres
         - name: PGDATA
           value: /var/lib/postgresql/data/pgdata
         livenessProbe:

--- a/specs/postgres/base/kustomization.yaml
+++ b/specs/postgres/base/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  app: postgres
+
+resources:
+- deployment.yaml
+- service.yaml
+- pvc.yaml

--- a/specs/postgres/base/pvc.yaml
+++ b/specs/postgres/base/pvc.yaml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: lb-postgres-data
+spec:
+  storageClassName: default # Change storage class as per k8s cluster.
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/specs/postgres/base/service.yaml
+++ b/specs/postgres/base/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: lb-postgres
+  name: lb-postgres-svc
+spec:
+  ports:
+  - name: postgres
+    port: 5432
+    protocol: TCP
+    targetPort: 5432
+  selector:
+    app: lb-postgres
+  type: ClusterIP

--- a/specs/postgres/setup-postgres.sh
+++ b/specs/postgres/setup-postgres.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euxo
+
+readonly WORK_DIR="$(mktemp -d)"
+STORAGE_CLASS_NAME=$1
+STORAGE_SIZE=$2
+NAMESPACE=$3
+DATABASE_DUMP_FILE_PATH=$4
+DATABASE_NAME=$5
+SQL_CREATE_DB_STMT="CREATE DATABASE $DATABASE_NAME;"
+
+mkdir -p overlays
+cat <<'EOF' > overlays/pv-patch.yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: lb-postgres-data
+spec:
+  storageClassName: STORAGE_CLASS_NAME
+  resources:
+    requests:
+      storage: STORAGE_SIZE
+EOF
+
+cat <<'EOF' > overlays/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  app: lb-postgres
+namespace: NAMESPACE
+resources:
+  - ../base
+patchesStrategicMerge:
+  - pv-patch.yaml
+EOF
+
+sed -i "s/STORAGE_CLASS_NAME/$STORAGE_CLASS_NAME/g" overlays/pv-patch.yaml
+sed -i "s/STORAGE_SIZE/$STORAGE_SIZE/g" overlays/pv-patch.yaml
+sed -i "s/NAMESPACE/$NAMESPACE/g" overlays/kustomization.yaml
+kubectl create ns "$NAMESPACE" || true
+kubectl kustomize overlays/ | kubectl apply -f -
+rm -rf overlays
+kubectl wait --for=condition=ready pod -l app=lb-postgres  -n "$NAMESPACE" --timeout 300s
+pushd "$WORK_DIR"
+aws s3 cp "$DATABASE_DUMP_FILE_PATH" dump.sql.gz
+gzip -d dump.sql.gz
+pgPod=$(kubectl get pods -l app=lb-postgres -o 'jsonpath={.items[0].metadata.name}')
+kubectl cp "$(ls *.sql)" "$pgPod":/tmp/
+filesList=$(kubectl exec deploy/lb-postgres -- ls /tmp/)
+kubectl exec deploy/lb-postgres -- psql --username pgbench -c "$SQL_CREATE_DB_STMT"
+kubectl exec deploy/lb-postgres -- psql --username pgbench -d "$DATABASE_NAME" -f /tmp/"$filesList"

--- a/specs/postgres/setup-postgres.sh
+++ b/specs/postgres/setup-postgres.sh
@@ -43,7 +43,11 @@ kubectl kustomize overlays/ | kubectl apply -f -
 rm -rf overlays
 kubectl wait --for=condition=ready pod -l app=lb-postgres  -n "$NAMESPACE" --timeout 300s
 pushd "$WORK_DIR"
-aws s3 cp "$DATABASE_DUMP_FILE_PATH" dump.sql.gz
+if [[ "$DATABASE_DUMP_FILE_PATH" == s3://* ]]; then
+  aws s3 cp "$DATABASE_DUMP_FILE_PATH" dump.sql.gz
+else
+  cp "$DATABASE_DUMP_FILE_PATH" dump.sql.gz
+fi
 gzip -d dump.sql.gz
 pgPod=$(kubectl get pods -l app=lb-postgres -o 'jsonpath={.items[0].metadata.name}')
 kubectl cp "$(ls *.sql)" "$pgPod":/tmp/


### PR DESCRIPTION
We have destroyed all common RDS instances for Postgres so if a dev wants to register Postgres datasource on Lightbeam they need to deploy a local postgres instance in their k8s cluster, dump the data there and then register on Lightbeam.