### PR TITLE
LA-0000 Add namespace flag to kubectl commands

### DIFF
--- a/specs/postgres/setup-postgres.sh
+++ b/specs/postgres/setup-postgres.sh
@@ -107,9 +107,9 @@ start_time=$(date +%s)
 while true
 do
     success=0
-    for pod_name in $(kubectl get pods -l app="$NAME" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}')
+    for pod_name in $(kubectl get pods -n $NAMESPACE -l app="$NAME" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}')
     do
-        if [[ $(kubectl  get po "$pod_name" -o jsonpath='{.status.containerStatuses[*].ready}') == 'true'  ]]
+        if [[ $(kubectl  get po -n $NAMESPACE "$pod_name" -o jsonpath='{.status.containerStatuses[*].ready}') == 'true'  ]]
           then
             echo "The postgres instance is ready with pod name $pod_name. Starting data dump now."
             success=1


### PR DESCRIPTION
- namespace flag was missing in two kubectl commands causing commands to not return pod name and status of pods since if we don't specify any namespace default namespace is assumed.

- we should specify lightbeam namespace since we are deploying this in that namespace