### PR TITLE
LA-2373 fix integer overflow for table rows count.

### DIFF
--- a/sql_user_check_redshift/table_rows_size_per_schema.sql
+++ b/sql_user_check_redshift/table_rows_size_per_schema.sql
@@ -2,7 +2,7 @@ SELECT
 	svt.schema,
 	count(svt.table),
 	sum(size) AS tbl_size_in_mb,
-	sum(tbl_rows::int)
+	sum(tbl_rows)
 FROM
 	svv_table_info AS svt
 GROUP BY


### PR DESCRIPTION
- we use the SQL query in table_rows_size_per_schema.sql this file to get size, table counts, total number of rows per schema. We encountered an integer overflow issue in one customer setup possibly due to large number of rows in a schema.
- Fix is to not typecast count of table rows to 4 byte integer (int datatype).
- some logs where this issue occured:

      psql:table_rows_size_per_schema.sql:9: ERROR:  Value out of range for 4 bytes.
      DETAIL:  
        -----------------------------------------------
        error:  Value out of range for 4 bytes.
        code:      8001
        context:   Input:2597884963.
        query:     10808843
        location:  numeric_bound.cpp:94
        process:   query0_105_10808843 [pid=8130]

