### PR TITLE
Update azure_jump_box.sh

### DIFF
--- a/azure_jump_box.sh
+++ b/azure_jump_box.sh
@@ -3,7 +3,8 @@
 sudo apt-get update
 sudo apt-get install -y unzip jq
 
-curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+#curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+curl -LO "https://dl.k8s.io/release/v1.25.0/bin/linux/amd64/kubectl"
 sudo chmod +x kubectl
 sudo mv kubectl /usr/local/bin/
 kubectl version


### PR DESCRIPTION
Updating to 1.25 kubectl as new version does not allow kubectl exec into the pod.