### PR TITLE
LA-14402 Add installer support for Ubuntu 24.04

### DIFF
--- a/Ubuntu/master.sh
+++ b/Ubuntu/master.sh
@@ -59,8 +59,24 @@ setenforce 0
 sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
 systemctl disable firewalld
 systemctl status firewalld
-rm /etc/containerd/config.toml
+
+mkdir -p /etc/containerd
+containerd config default | tee /etc/containerd/config.toml > /dev/null
+sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
 systemctl restart containerd
+
+# Load necessary kernel modules.
+modprobe overlay
+modprobe br_netfilter
+
+# Set required sysctl parameters.
+cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+net.bridge.bridge-nf-call-iptables  = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+net.ipv4.ip_forward                 = 1
+EOF
+
+sysctl --system
 
 export dotCount=0
 export maxDots=15
@@ -126,9 +142,9 @@ function serviceStatusCheck() {
 echo "2. Install kubeadm, kubectl and kubelet:"
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 mkdir -p /etc/apt/keyrings
-echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-apt-get update -y && apt-get install -y kubelet=1.28.8-1.1 kubeadm=1.28.8-1.1 kubectl=1.28.8-1.1
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.30/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+apt-get update -y && apt-get install -y kubelet=1.30.0-1.1 kubeadm=1.30.0-1.1 kubectl=1.30.6-1.1
 systemctl daemon-reload && systemctl start kubelet && systemctl enable kubelet && systemctl status kubelet
 serviceStatusCheck "kubelet.service" "False"
 
@@ -142,7 +158,7 @@ rm -rf $HOME/.kube
 mkdir -p $HOME/.kube && cp -i /etc/kubernetes/admin.conf $HOME/.kube/config && chown $(id -u):$(id -g) $HOME/.kube/config
 
 echo "5. Install network driver:"
-curl https://raw.githubusercontent.com/projectcalico/calico/v3.25.1/manifests/calico.yaml -O && kubectl apply -f calico.yaml
+curl https://raw.githubusercontent.com/projectcalico/calico/v3.29.0/manifests/calico.yaml -O && kubectl apply -f calico.yaml
 
 while true
   do

--- a/Ubuntu/master.sh
+++ b/Ubuntu/master.sh
@@ -60,6 +60,8 @@ sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
 systemctl disable firewalld
 systemctl status firewalld
 
+# Containerd needs to be configured to use systemd cgroup driver to align with kubelet's cgroup management.
+# The SystemdCgroup setting tells containerd to use systemd to manage container cgroups instead of cgroupfs.
 mkdir -p /etc/containerd
 containerd config default | tee /etc/containerd/config.toml > /dev/null
 sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml

--- a/Ubuntu/worker.sh
+++ b/Ubuntu/worker.sh
@@ -58,6 +58,8 @@ sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
 systemctl disable firewalld
 systemctl status firewalld
 
+# Containerd needs to be configured to use systemd cgroup driver to align with kubelet's cgroup management.
+# The SystemdCgroup setting tells containerd to use systemd to manage container cgroups instead of cgroupfs.
 mkdir -p /etc/containerd
 containerd config default | tee /etc/containerd/config.toml > /dev/null
 sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml

--- a/Ubuntu/worker.sh
+++ b/Ubuntu/worker.sh
@@ -57,8 +57,24 @@ setenforce 0
 sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
 systemctl disable firewalld
 systemctl status firewalld
-rm /etc/containerd/config.toml
+
+mkdir -p /etc/containerd
+containerd config default | tee /etc/containerd/config.toml > /dev/null
+sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
 systemctl restart containerd
+
+# Load necessary kernel modules.
+modprobe overlay
+modprobe br_netfilter
+
+# Set required sysctl parameters.
+cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+net.bridge.bridge-nf-call-iptables  = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+net.ipv4.ip_forward                 = 1
+EOF
+
+sysctl --system
 
 export dotCount=0
 export maxDots=15
@@ -124,9 +140,9 @@ function serviceStatusCheck() {
 echo "2. Install kubeadm, kubectl and kubelet:"
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 mkdir -p /etc/apt/keyrings
-echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-apt-get update -y && apt-get install -y kubelet=1.28.8-1.1 kubeadm=1.28.8-1.1 kubectl=1.28.8-1.1
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.30/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+apt-get update -y && apt-get install -y kubelet=1.30.0-1.1 kubeadm=1.30.0-1.1 kubectl=1.30.6-1.1
 systemctl daemon-reload && systemctl start kubelet && systemctl enable kubelet && systemctl status kubelet
 serviceStatusCheck "kubelet.service" "False"
 


### PR DESCRIPTION
I am making changes in the lb-installer to support Ubuntu 24.04, Kubernetes version 1.30 and Calico 3.29. 

1. We are now creating a new config to ask containerd to use cgroup driver instead of cgroupfs. Kubelet uses cgroup driver to manage container resources. Now if containerd tried to manage that resource using cgroupfs , it will fail to do it.

Without alignment:
- kubelet tries to manage Pod "A" with systemd cgroups
- containerd tries to manage same Pod "A" with cgroupfs
- Result: conflicting resource controls

2. Additional networking configuration is being done.

- Enabling the overlay filesystem used by container runtimes
- Enabling bridge networking filtering. This allows iptables to see bridged network traffic.
