### PR TITLE
LA-21983 Increase Ulimit for kubeadm clusters

### DIFF
--- a/RHEL-offline/master-offline.sh
+++ b/RHEL-offline/master-offline.sh
@@ -4,6 +4,8 @@
 # Usage: sudo bash master-offline.sh <path-to-bundle-dir>
 #   e.g. sudo bash master-offline.sh /home/ec2-user/lb-offline-bundle-rhel9
 
+ULIMIT=1048576
+
 if [ "$EUID" -ne 0 ]; then
   echo "Please run as root."
   exit 1
@@ -60,6 +62,33 @@ fi
 mkdir -p /etc/containerd
 containerd config default | tee /etc/containerd/config.toml > /dev/null
 sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
+
+# Configure open file descriptor ulimit
+# Done here at node setup time so containerd starts with the correct limit
+# from the very first launch — no DaemonSet run required after cluster init.
+#
+# Two settings must be raised in order (each acts as a ceiling for the next):
+#   1. fs.nr_open  — kernel hard ceiling; no process can exceed this
+#   2. LimitNOFILE — containerd's systemd service limit, inherited by all pods
+echo "Configuring open file descriptor ulimit to $ULIMIT..."
+
+# Step 1: raise and persist the kernel ceiling
+sysctl -w fs.nr_open=$ULIMIT
+sed -i '/^fs\.nr_open/d' /etc/sysctl.conf
+echo "fs.nr_open = $ULIMIT" >> /etc/sysctl.conf
+echo "  [OK] fs.nr_open set to $ULIMIT"
+
+# Step 2: write the containerd systemd drop-in
+mkdir -p /etc/systemd/system/containerd.service.d
+cat <<EOF > /etc/systemd/system/containerd.service.d/ulimits.conf
+[Service]
+LimitNOFILE=$ULIMIT
+EOF
+echo "  [OK] containerd drop-in written"
+
+# Reload systemd so it picks up the new drop-in before the restart below
+systemctl daemon-reload
+
 systemctl restart containerd
 
 # Create the .conf file to load the modules at bootup
@@ -282,3 +311,18 @@ echo "Done! Ready to deploy LightBeam Cluster!!"
 # Pin packages to avoid auto upgrade.
 # On RHEL 9, versionlock is included in python3-dnf-plugins-core (already installed).
 sudo dnf versionlock add kubelet kubeadm kubectl docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+# Verify ulimit was applied correctly
+echo ""
+echo "=== Ulimit Verification ==="
+ACTUAL_NR_OPEN=$(sysctl -n fs.nr_open)
+CONTAINERD_PID=$(pidof containerd | cut -d" " -f1)
+ACTUAL_LIMIT=$(grep "Max open files" /proc/$CONTAINERD_PID/limits | awk '{print $5}')
+echo "  fs.nr_open              : $ACTUAL_NR_OPEN  (expected $ULIMIT)"
+echo "  containerd LimitNOFILE  : $ACTUAL_LIMIT  (expected $ULIMIT)"
+if [ "$ACTUAL_NR_OPEN" -eq "$ULIMIT" ] && [ "$ACTUAL_LIMIT" -eq "$ULIMIT" ]; then
+    echo "  [OK] Ulimit configured correctly."
+else
+    echo "  [WARN] Ulimit mismatch — check systemd applied the drop-in:"
+    echo "         systemctl show containerd | grep LimitNOFILE"
+fi

--- a/RHEL-offline/worker-offline.sh
+++ b/RHEL-offline/worker-offline.sh
@@ -4,6 +4,8 @@
 # Usage: sudo bash worker-offline.sh <path-to-bundle-dir>
 #   e.g. sudo bash worker-offline.sh /home/ec2-user/lb-offline-bundle-rhel9
 
+ULIMIT=1048576
+
 if [ "$EUID" -ne 0 ]; then
   echo "Please run as root."
   exit 1
@@ -54,6 +56,33 @@ fi
 mkdir -p /etc/containerd
 containerd config default | tee /etc/containerd/config.toml > /dev/null
 sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
+
+# Configure open file descriptor ulimit
+# Done here at node setup time so containerd starts with the correct limit
+# from the very first launch — no DaemonSet run required after cluster init.
+#
+# Two settings must be raised in order (each acts as a ceiling for the next):
+#   1. fs.nr_open  — kernel hard ceiling; no process can exceed this
+#   2. LimitNOFILE — containerd's systemd service limit, inherited by all pods
+echo "Configuring open file descriptor ulimit to $ULIMIT..."
+
+# Step 1: raise and persist the kernel ceiling
+sysctl -w fs.nr_open=$ULIMIT
+sed -i '/^fs\.nr_open/d' /etc/sysctl.conf
+echo "fs.nr_open = $ULIMIT" >> /etc/sysctl.conf
+echo "  [OK] fs.nr_open set to $ULIMIT"
+
+# Step 2: write the containerd systemd drop-in
+mkdir -p /etc/systemd/system/containerd.service.d
+cat <<EOF > /etc/systemd/system/containerd.service.d/ulimits.conf
+[Service]
+LimitNOFILE=$ULIMIT
+EOF
+echo "  [OK] containerd drop-in written"
+
+# Reload systemd so it picks up the new drop-in before the restart below
+systemctl daemon-reload
+
 systemctl restart containerd
 
 # Create the .conf file to load the modules at bootup
@@ -156,3 +185,18 @@ serviceStatusCheck "kubelet.service" "False"
 # Pin packages to avoid auto upgrade.
 # On RHEL 9, versionlock is included in python3-dnf-plugins-core (already installed).
 sudo dnf versionlock add kubelet kubeadm kubectl docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+# Verify ulimit was applied correctly
+echo ""
+echo "=== Ulimit Verification ==="
+ACTUAL_NR_OPEN=$(sysctl -n fs.nr_open)
+CONTAINERD_PID=$(pidof containerd | cut -d" " -f1)
+ACTUAL_LIMIT=$(grep "Max open files" /proc/$CONTAINERD_PID/limits | awk '{print $5}')
+echo "  fs.nr_open              : $ACTUAL_NR_OPEN  (expected $ULIMIT)"
+echo "  containerd LimitNOFILE  : $ACTUAL_LIMIT  (expected $ULIMIT)"
+if [ "$ACTUAL_NR_OPEN" -eq "$ULIMIT" ] && [ "$ACTUAL_LIMIT" -eq "$ULIMIT" ]; then
+    echo "  [OK] Ulimit configured correctly."
+else
+    echo "  [WARN] Ulimit mismatch — check systemd applied the drop-in:"
+    echo "         systemctl show containerd | grep LimitNOFILE"
+fi

--- a/RHEL/master.sh
+++ b/RHEL/master.sh
@@ -7,6 +7,8 @@ fi
 
 sudo yum update -y
 
+ULIMIT=1048576
+
 grep -qxF 'export PATH="/usr/local/bin:$PATH"' ~/.bashrc || echo 'export PATH="/usr/local/bin:$PATH"' >> ~/.bashrc
 source ~/.bashrc
 
@@ -33,6 +35,7 @@ else
    echo "Failed to update docker cgroup driver is updated to systemd"
    exit 1
 fi
+
 # Set up monthly Docker prune cron job (runs at 3 AM on the 1st of every month)
 echo "Setting up Docker prune cron job..."
 if ! crontab -l 2>/dev/null | grep -q "docker system prune"; then
@@ -41,12 +44,40 @@ if ! crontab -l 2>/dev/null | grep -q "docker system prune"; then
 else
   echo "Docker prune cron job already exists. Skipping."
 fi
+
 # Containerd needs to be configured to use systemd cgroup driver to align with kubelet's cgroup management.
 # The SystemdCgroup setting tells containerd to use systemd to manage container cgroups instead of cgroupfs.
 # containerd.io is already installed above via the Docker repo — no separate install needed.
 mkdir -p /etc/containerd
 containerd config default | tee /etc/containerd/config.toml > /dev/null
 sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
+
+# Configure open file descriptor ulimit
+# Done here at node setup time so containerd starts with the correct limit
+# from the very first launch — no DaemonSet run required after cluster init.
+#
+# Two settings must be raised in order (each acts as a ceiling for the next):
+#   1. fs.nr_open  — kernel hard ceiling; no process can exceed this
+#   2. LimitNOFILE — containerd's systemd service limit, inherited by all pods
+echo "Configuring open file descriptor ulimit to $ULIMIT..."
+
+# Step 1: raise and persist the kernel ceiling
+sysctl -w fs.nr_open=$ULIMIT
+sed -i '/^fs\.nr_open/d' /etc/sysctl.conf
+echo "fs.nr_open = $ULIMIT" >> /etc/sysctl.conf
+echo "  [OK] fs.nr_open set to $ULIMIT"
+
+# Step 2: write the containerd systemd drop-in
+mkdir -p /etc/systemd/system/containerd.service.d
+cat <<EOF > /etc/systemd/system/containerd.service.d/ulimits.conf
+[Service]
+LimitNOFILE=$ULIMIT
+EOF
+echo "  [OK] containerd drop-in written"
+
+# Reload systemd so it picks up the new drop-in before the restart below
+systemctl daemon-reload
+
 systemctl restart containerd
 
 # Create the .conf file to load the modules at bootup
@@ -279,3 +310,18 @@ echo "Done! Ready to deploy LightBeam Cluster!!"
 # Pin packages to avoid auto upgrade.
 sudo dnf install -y python3-dnf-plugin-versionlock
 sudo dnf versionlock add kubelet kubeadm kubectl docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+# Verify ulimit was applied correctly
+echo ""
+echo "=== Ulimit Verification ==="
+ACTUAL_NR_OPEN=$(sysctl -n fs.nr_open)
+CONTAINERD_PID=$(pidof containerd | cut -d" " -f1)
+ACTUAL_LIMIT=$(grep "Max open files" /proc/$CONTAINERD_PID/limits | awk '{print $5}')
+echo "  fs.nr_open              : $ACTUAL_NR_OPEN  (expected $ULIMIT)"
+echo "  containerd LimitNOFILE  : $ACTUAL_LIMIT  (expected $ULIMIT)"
+if [ "$ACTUAL_NR_OPEN" -eq "$ULIMIT" ] && [ "$ACTUAL_LIMIT" -eq "$ULIMIT" ]; then
+    echo "  [OK] Ulimit configured correctly."
+else
+    echo "  [WARN] Ulimit mismatch — check systemd applied the drop-in:"
+    echo "         systemctl show containerd | grep LimitNOFILE"
+fi

--- a/RHEL/worker.sh
+++ b/RHEL/worker.sh
@@ -7,6 +7,8 @@ fi
 
 sudo yum update -y
 
+ULIMIT=1048576
+
 grep -qxF 'export PATH="/usr/local/bin:$PATH"' ~/.bashrc || echo 'export PATH="/usr/local/bin:$PATH"' >> ~/.bashrc
 source ~/.bashrc
 
@@ -40,6 +42,33 @@ fi
 mkdir -p /etc/containerd
 containerd config default | tee /etc/containerd/config.toml > /dev/null
 sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
+
+# Configure open file descriptor ulimit
+# Done here at node setup time so containerd starts with the correct limit
+# from the very first launch — no DaemonSet run required after cluster init.
+#
+# Two settings must be raised in order (each acts as a ceiling for the next):
+#   1. fs.nr_open  — kernel hard ceiling; no process can exceed this
+#   2. LimitNOFILE — containerd's systemd service limit, inherited by all pods
+echo "Configuring open file descriptor ulimit to $ULIMIT..."
+
+# Step 1: raise and persist the kernel ceiling
+sysctl -w fs.nr_open=$ULIMIT
+sed -i '/^fs\.nr_open/d' /etc/sysctl.conf
+echo "fs.nr_open = $ULIMIT" >> /etc/sysctl.conf
+echo "  [OK] fs.nr_open set to $ULIMIT"
+
+# Step 2: write the containerd systemd drop-in
+mkdir -p /etc/systemd/system/containerd.service.d
+cat <<EOF > /etc/systemd/system/containerd.service.d/ulimits.conf
+[Service]
+LimitNOFILE=$ULIMIT
+EOF
+echo "  [OK] containerd drop-in written"
+
+# Reload systemd so it picks up the new drop-in before the restart below
+systemctl daemon-reload
+
 systemctl restart containerd
 
 # Create the .conf file to load the modules at bootup
@@ -156,3 +185,18 @@ serviceStatusCheck "kubelet.service" "False"
 # Pin packages to avoid auto upgrade.
 sudo dnf install -y python3-dnf-plugin-versionlock
 sudo dnf versionlock add kubelet kubeadm kubectl docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+# Verify ulimit was applied correctly
+echo ""
+echo "=== Ulimit Verification ==="
+ACTUAL_NR_OPEN=$(sysctl -n fs.nr_open)
+CONTAINERD_PID=$(pidof containerd | cut -d" " -f1)
+ACTUAL_LIMIT=$(grep "Max open files" /proc/$CONTAINERD_PID/limits | awk '{print $5}')
+echo "  fs.nr_open              : $ACTUAL_NR_OPEN  (expected $ULIMIT)"
+echo "  containerd LimitNOFILE  : $ACTUAL_LIMIT  (expected $ULIMIT)"
+if [ "$ACTUAL_NR_OPEN" -eq "$ULIMIT" ] && [ "$ACTUAL_LIMIT" -eq "$ULIMIT" ]; then
+    echo "  [OK] Ulimit configured correctly."
+else
+    echo "  [WARN] Ulimit mismatch — check systemd applied the drop-in:"
+    echo "         systemctl show containerd | grep LimitNOFILE"
+fi

--- a/Ubuntu/master.sh
+++ b/Ubuntu/master.sh
@@ -7,6 +7,7 @@ fi
 
 TIMEOUT=300
 SLEEP_INTERVAL=1
+ULIMIT=1048576
 
 # Remove all older packages.
 apt-get -y remove docker docker-engine docker.io containerd runc kubeadm kubelet kubectl
@@ -82,6 +83,33 @@ fi
 mkdir -p /etc/containerd
 containerd config default | tee /etc/containerd/config.toml > /dev/null
 sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
+
+# Configure open file descriptor ulimit
+# Done here at node setup time so containerd starts with the correct limit
+# from the very first launch — no DaemonSet run required after cluster init.
+#
+# Two settings must be raised in order (each acts as a ceiling for the next):
+#   1. fs.nr_open  — kernel hard ceiling; no process can exceed this
+#   2. LimitNOFILE — containerd's systemd service limit, inherited by all pods
+echo "Configuring open file descriptor ulimit to $ULIMIT..."
+
+# Step 1: raise and persist the kernel ceiling
+sysctl -w fs.nr_open=$ULIMIT
+sed -i '/^fs\.nr_open/d' /etc/sysctl.conf
+echo "fs.nr_open = $ULIMIT" >> /etc/sysctl.conf
+echo "  [OK] fs.nr_open set to $ULIMIT"
+
+# Step 2: write the containerd systemd drop-in
+mkdir -p /etc/systemd/system/containerd.service.d
+cat <<EOF > /etc/systemd/system/containerd.service.d/ulimits.conf
+[Service]
+LimitNOFILE=$ULIMIT
+EOF
+echo "  [OK] containerd drop-in written"
+
+# Reload systemd so it picks up the new drop-in before the restart below
+systemctl daemon-reload
+
 systemctl restart containerd
 
 # Load necessary kernel modules.
@@ -401,3 +429,17 @@ apt-mark hold snapd
 apt-mark hold systemd
 apt-mark hold systemd-sysv
 apt-mark hold systemd-timesyncd
+
+# Verify ulimit was applied correctly
+echo ""
+echo "=== Ulimit Verification ==="
+ACTUAL_NR_OPEN=$(sysctl -n fs.nr_open)
+CONTAINERD_PID=$(pidof containerd | cut -d" " -f1)
+ACTUAL_LIMIT=$(grep "Max open files" /proc/$CONTAINERD_PID/limits | awk '{print $5}')
+echo "  fs.nr_open              : $ACTUAL_NR_OPEN  (expected $ULIMIT)"
+echo "  containerd LimitNOFILE  : $ACTUAL_LIMIT  (expected $ULIMIT)"
+if [ "$ACTUAL_NR_OPEN" -eq "$ULIMIT" ] && [ "$ACTUAL_LIMIT" -eq "$ULIMIT" ]; then
+    echo "  [OK] Ulimit configured correctly."
+else
+    echo "  [WARN] Ulimit mismatch — run installer/ulimit-daemonset.py to correct worker nodes."
+fi

--- a/Ubuntu/worker.sh
+++ b/Ubuntu/worker.sh
@@ -7,6 +7,7 @@ fi
 
 TIMEOUT=300
 SLEEP_INTERVAL=1
+ULIMIT=1048576
 
 # Remove all older packages.
 apt-get -y remove docker docker-engine docker.io containerd runc kubeadm kubelet kubectl
@@ -72,6 +73,33 @@ fi
 mkdir -p /etc/containerd
 containerd config default | tee /etc/containerd/config.toml > /dev/null
 sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
+
+# Configure open file descriptor ulimit
+# Done here at node setup time so containerd starts with the correct limit
+# from the very first launch — no DaemonSet run required after cluster init.
+#
+# Two settings must be raised in order (each acts as a ceiling for the next):
+#   1. fs.nr_open  — kernel hard ceiling; no process can exceed this
+#   2. LimitNOFILE — containerd's systemd service limit, inherited by all pods
+echo "Configuring open file descriptor ulimit to $ULIMIT..."
+
+# Step 1: raise and persist the kernel ceiling
+sysctl -w fs.nr_open=$ULIMIT
+sed -i '/^fs\.nr_open/d' /etc/sysctl.conf
+echo "fs.nr_open = $ULIMIT" >> /etc/sysctl.conf
+echo "  [OK] fs.nr_open set to $ULIMIT"
+
+# Step 2: write the containerd systemd drop-in
+mkdir -p /etc/systemd/system/containerd.service.d
+cat <<EOF > /etc/systemd/system/containerd.service.d/ulimits.conf
+[Service]
+LimitNOFILE=$ULIMIT
+EOF
+echo "  [OK] containerd drop-in written"
+
+# Reload systemd so it picks up the new drop-in before the restart below
+systemctl daemon-reload
+
 systemctl restart containerd
 
 # Load necessary kernel modules.
@@ -207,3 +235,17 @@ apt-mark hold snapd
 apt-mark hold systemd
 apt-mark hold systemd-sysv
 apt-mark hold systemd-timesyncd
+
+# Verify ulimit was applied correctly
+echo ""
+echo "=== Ulimit Verification ==="
+ACTUAL_NR_OPEN=$(sysctl -n fs.nr_open)
+CONTAINERD_PID=$(pidof containerd | cut -d" " -f1)
+ACTUAL_LIMIT=$(grep "Max open files" /proc/$CONTAINERD_PID/limits | awk '{print $5}')
+echo "  fs.nr_open              : $ACTUAL_NR_OPEN  (expected $ULIMIT)"
+echo "  containerd LimitNOFILE  : $ACTUAL_LIMIT  (expected $ULIMIT)"
+if [ "$ACTUAL_NR_OPEN" -eq "$ULIMIT" ] && [ "$ACTUAL_LIMIT" -eq "$ULIMIT" ]; then
+    echo "  [OK] Ulimit configured correctly."
+else
+    echo "  [WARN] Ulimit mismatch — run installer/ulimit-daemonset.py to correct worker nodes."
+fi


### PR DESCRIPTION
By default, Linux sets a nofile ulimit of 1024, which controls the maximum number of open file descriptors a process can hold. Our services require a significantly higher limit due to the volume of simultaneous file descriptors in use. Without raising this limit, pods may encounter "too many open files" errors, causing service degradation. We will be setting the ulimit to "1048576" with the help of the installer scripts for fresh installations moving forward.

