### PR TITLE
 LA-22613 Improve kex hardening logic

### DIFF
--- a/Ubuntu/master.sh
+++ b/Ubuntu/master.sh
@@ -16,40 +16,38 @@ CURRENT_GSSKEX=$(sshd -T | grep "^gssapikexalgorithms" | awk '{print $2}')
 # Remove all DHE algorithms
 HARDENED_KEX=$(echo "$CURRENT_KEX" | tr ',' '\n' | grep -v "diffie-hellman" | paste -sd ',' -)
 if [ -z "$HARDENED_KEX" ]; then
-  echo "No non-DHE KEX algorithms found — aborting hardening"
-  return 1
-fi
-
-# Handle GSSAPI KEX
-GSSKEX_LINE=""
-if [ -n "$CURRENT_GSSKEX" ]; then
-  HARDENED_GSSKEX=$(echo "$CURRENT_GSSKEX" | tr ',' '\n' | grep -v "gss-group14\|gss-group16\|gss-gex" | paste -sd ',' -)
-  if [ -z "$HARDENED_GSSKEX" ]; then
-    echo "GSSAPIKexAlgorithms: empty after hardening — disabling GSSAPI KEX"
-    GSSKEX_LINE="GSSAPIAuthentication no"
-  else
-    GSSKEX_LINE="GSSAPIKexAlgorithms $HARDENED_GSSKEX
-GSSAPIAuthentication yes"
-  fi
+  echo "No non-DHE KEX algorithms found — skipping hardening"
 else
-  echo "GSSAPI KEX not supported on this system — skipping"
-fi
+  # Handle GSSAPI KEX
+  GSSKEX_LINE=""
+  if [ -n "$CURRENT_GSSKEX" ]; then
+    HARDENED_GSSKEX=$(echo "$CURRENT_GSSKEX" | tr ',' '\n' | grep -v "gss-group14\|gss-group16\|gss-gex" | paste -sd ',' -)
+    if [ -z "$HARDENED_GSSKEX" ]; then
+      echo "GSSAPIKexAlgorithms: empty after hardening — disabling GSSAPI KEX"
+      GSSKEX_LINE="GSSAPIAuthentication no"
+    else
+      GSSKEX_LINE="GSSAPIKexAlgorithms $HARDENED_GSSKEX
+GSSAPIAuthentication yes"
+    fi
+  else
+    echo "GSSAPI KEX not supported on this system — skipping"
+  fi
 
-echo "Writing config to /etc/ssh/sshd_config.d/kex-hardening.conf"
-cat > /etc/ssh/sshd_config.d/kex-hardening.conf << EOF
+  echo "Writing config to /etc/ssh/sshd_config.d/kex-hardening.conf"
+  cat > /etc/ssh/sshd_config.d/kex-hardening.conf << EOF
 KexAlgorithms $HARDENED_KEX
 $GSSKEX_LINE
 EOF
 
-echo "Validating config..."
-if sshd -t; then
-  echo "Config valid — restarting SSH"
-  systemctl restart ssh || systemctl restart sshd
-else
-  echo "Config invalid — reverting"
-  rm /etc/ssh/sshd_config.d/kex-hardening.conf
-  echo -e "\e[31mSSH hardening failed\e[0m"
-  return 1
+  echo "Validating config..."
+  if sshd -t; then
+    echo "Config valid — restarting SSH"
+    systemctl restart ssh || systemctl restart sshd
+  else
+    echo "Config invalid — reverting"
+    rm /etc/ssh/sshd_config.d/kex-hardening.conf
+    echo -e "\e[31mSSH hardening failed\e[0m"
+  fi
 fi
 
 # Remove all older packages.

--- a/Ubuntu/master.sh
+++ b/Ubuntu/master.sh
@@ -12,20 +12,35 @@ ULIMIT=1048576
 echo "Hardening sshd..."
 CURRENT_KEX=$(sshd -T | grep "^kexalgorithms" | awk '{print $2}')
 CURRENT_GSSKEX=$(sshd -T | grep "^gssapikexalgorithms" | awk '{print $2}')
+
 # Remove all DHE algorithms
 HARDENED_KEX=$(echo "$CURRENT_KEX" | tr ',' '\n' | grep -v "diffie-hellman" | paste -sd ',' -)
-HARDENED_GSSKEX=$(echo "$CURRENT_GSSKEX" | tr ',' '\n' | grep -v "gss-group14\|gss-group16\|gss-gex" | paste -sd ',' - || echo "")
-if [ -z "$HARDENED_GSSKEX" ]; then
-  echo "GSSAPIKexAlgorithms: empty — will disable GSSAPI KEX"
-  GSSKEX_LINE="GSSAPIAuthentication no"
-else
-  GSSKEX_LINE="GSSAPIKexAlgorithms $HARDENED_GSSKEX"
+if [ -z "$HARDENED_KEX" ]; then
+  echo "No non-DHE KEX algorithms found — aborting hardening"
+  return 1
 fi
+
+# Handle GSSAPI KEX
+GSSKEX_LINE=""
+if [ -n "$CURRENT_GSSKEX" ]; then
+  HARDENED_GSSKEX=$(echo "$CURRENT_GSSKEX" | tr ',' '\n' | grep -v "gss-group14\|gss-group16\|gss-gex" | paste -sd ',' -)
+  if [ -z "$HARDENED_GSSKEX" ]; then
+    echo "GSSAPIKexAlgorithms: empty after hardening — disabling GSSAPI KEX"
+    GSSKEX_LINE="GSSAPIAuthentication no"
+  else
+    GSSKEX_LINE="GSSAPIKexAlgorithms $HARDENED_GSSKEX
+GSSAPIAuthentication yes"
+  fi
+else
+  echo "GSSAPI KEX not supported on this system — skipping"
+fi
+
 echo "Writing config to /etc/ssh/sshd_config.d/kex-hardening.conf"
 cat > /etc/ssh/sshd_config.d/kex-hardening.conf << EOF
 KexAlgorithms $HARDENED_KEX
 $GSSKEX_LINE
 EOF
+
 echo "Validating config..."
 if sshd -t; then
   echo "Config valid — restarting SSH"
@@ -34,6 +49,7 @@ else
   echo "Config invalid — reverting"
   rm /etc/ssh/sshd_config.d/kex-hardening.conf
   echo -e "\e[31mSSH hardening failed\e[0m"
+  return 1
 fi
 
 # Remove all older packages.

--- a/Ubuntu/worker.sh
+++ b/Ubuntu/worker.sh
@@ -16,40 +16,38 @@ CURRENT_GSSKEX=$(sshd -T | grep "^gssapikexalgorithms" | awk '{print $2}')
 # Remove all DHE algorithms
 HARDENED_KEX=$(echo "$CURRENT_KEX" | tr ',' '\n' | grep -v "diffie-hellman" | paste -sd ',' -)
 if [ -z "$HARDENED_KEX" ]; then
-  echo "No non-DHE KEX algorithms found — aborting hardening"
-  return 1
-fi
-
-# Handle GSSAPI KEX
-GSSKEX_LINE=""
-if [ -n "$CURRENT_GSSKEX" ]; then
-  HARDENED_GSSKEX=$(echo "$CURRENT_GSSKEX" | tr ',' '\n' | grep -v "gss-group14\|gss-group16\|gss-gex" | paste -sd ',' -)
-  if [ -z "$HARDENED_GSSKEX" ]; then
-    echo "GSSAPIKexAlgorithms: empty after hardening — disabling GSSAPI KEX"
-    GSSKEX_LINE="GSSAPIAuthentication no"
-  else
-    GSSKEX_LINE="GSSAPIKexAlgorithms $HARDENED_GSSKEX
-GSSAPIAuthentication yes"
-  fi
+  echo "No non-DHE KEX algorithms found — skipping hardening"
 else
-  echo "GSSAPI KEX not supported on this system — skipping"
-fi
+  # Handle GSSAPI KEX
+  GSSKEX_LINE=""
+  if [ -n "$CURRENT_GSSKEX" ]; then
+    HARDENED_GSSKEX=$(echo "$CURRENT_GSSKEX" | tr ',' '\n' | grep -v "gss-group14\|gss-group16\|gss-gex" | paste -sd ',' -)
+    if [ -z "$HARDENED_GSSKEX" ]; then
+      echo "GSSAPIKexAlgorithms: empty after hardening — disabling GSSAPI KEX"
+      GSSKEX_LINE="GSSAPIAuthentication no"
+    else
+      GSSKEX_LINE="GSSAPIKexAlgorithms $HARDENED_GSSKEX
+GSSAPIAuthentication yes"
+    fi
+  else
+    echo "GSSAPI KEX not supported on this system — skipping"
+  fi
 
-echo "Writing config to /etc/ssh/sshd_config.d/kex-hardening.conf"
-cat > /etc/ssh/sshd_config.d/kex-hardening.conf << EOF
+  echo "Writing config to /etc/ssh/sshd_config.d/kex-hardening.conf"
+  cat > /etc/ssh/sshd_config.d/kex-hardening.conf << EOF
 KexAlgorithms $HARDENED_KEX
 $GSSKEX_LINE
 EOF
 
-echo "Validating config..."
-if sshd -t; then
-  echo "Config valid — restarting SSH"
-  systemctl restart ssh || systemctl restart sshd
-else
-  echo "Config invalid — reverting"
-  rm /etc/ssh/sshd_config.d/kex-hardening.conf
-  echo -e "\e[31mSSH hardening failed\e[0m"
-  return 1
+  echo "Validating config..."
+  if sshd -t; then
+    echo "Config valid — restarting SSH"
+    systemctl restart ssh || systemctl restart sshd
+  else
+    echo "Config invalid — reverting"
+    rm /etc/ssh/sshd_config.d/kex-hardening.conf
+    echo -e "\e[31mSSH hardening failed\e[0m"
+  fi
 fi
 
 # Remove all older packages.

--- a/Ubuntu/worker.sh
+++ b/Ubuntu/worker.sh
@@ -12,20 +12,35 @@ ULIMIT=1048576
 echo "Hardening sshd..."
 CURRENT_KEX=$(sshd -T | grep "^kexalgorithms" | awk '{print $2}')
 CURRENT_GSSKEX=$(sshd -T | grep "^gssapikexalgorithms" | awk '{print $2}')
+
 # Remove all DHE algorithms
 HARDENED_KEX=$(echo "$CURRENT_KEX" | tr ',' '\n' | grep -v "diffie-hellman" | paste -sd ',' -)
-HARDENED_GSSKEX=$(echo "$CURRENT_GSSKEX" | tr ',' '\n' | grep -v "gss-group14\|gss-group16\|gss-gex" | paste -sd ',' - || echo "")
-if [ -z "$HARDENED_GSSKEX" ]; then
-  echo "GSSAPIKexAlgorithms: empty — will disable GSSAPI KEX"
-  GSSKEX_LINE="GSSAPIAuthentication no"
-else
-  GSSKEX_LINE="GSSAPIKexAlgorithms $HARDENED_GSSKEX"
+if [ -z "$HARDENED_KEX" ]; then
+  echo "No non-DHE KEX algorithms found — aborting hardening"
+  return 1
 fi
+
+# Handle GSSAPI KEX
+GSSKEX_LINE=""
+if [ -n "$CURRENT_GSSKEX" ]; then
+  HARDENED_GSSKEX=$(echo "$CURRENT_GSSKEX" | tr ',' '\n' | grep -v "gss-group14\|gss-group16\|gss-gex" | paste -sd ',' -)
+  if [ -z "$HARDENED_GSSKEX" ]; then
+    echo "GSSAPIKexAlgorithms: empty after hardening — disabling GSSAPI KEX"
+    GSSKEX_LINE="GSSAPIAuthentication no"
+  else
+    GSSKEX_LINE="GSSAPIKexAlgorithms $HARDENED_GSSKEX
+GSSAPIAuthentication yes"
+  fi
+else
+  echo "GSSAPI KEX not supported on this system — skipping"
+fi
+
 echo "Writing config to /etc/ssh/sshd_config.d/kex-hardening.conf"
 cat > /etc/ssh/sshd_config.d/kex-hardening.conf << EOF
 KexAlgorithms $HARDENED_KEX
 $GSSKEX_LINE
 EOF
+
 echo "Validating config..."
 if sshd -t; then
   echo "Config valid — restarting SSH"
@@ -34,6 +49,7 @@ else
   echo "Config invalid — reverting"
   rm /etc/ssh/sshd_config.d/kex-hardening.conf
   echo -e "\e[31mSSH hardening failed\e[0m"
+  return 1
 fi
 
 # Remove all older packages.


### PR DESCRIPTION
Make the logic more failure proof for edge cases:
 
1. All KEX algorithms are DHE (new guard)
If filtering out diffie-hellman algorithms leaves HARDENED_KEX empty — meaning the system only has DHE algorithms — the script now skips hardening entirely instead of writing an empty KexAlgorithms line, which would break sshd config validation.

2. GSSAPI KEX not configured on the system (new guard)
Before, HARDENED_GSSKEX was computed unconditionally even when CURRENT_GSSKEX was empty (i.e. GSSAPI KEX isn't used). Now it checks if [ -n "$CURRENT_GSSKEX" ] first and skips the GSSAPI block entirely, leaving GSSKEX_LINE empty so nothing is written for it.

3. GSSAPI KEX becomes empty after hardening (pre-existing, but now correctly scoped)
When GSSAPI is present but all its algorithms are weak (gss-group14, gss-group16, gss-gex), the hardened list is empty and the script disables GSSAPI entirely via GSSAPIAuthentication no. This existed before but was also firing when GSSAPI wasn't present at all — now it only fires when appropriate.

4. Explicit GSSAPIAuthentication yes when GSSAPI is retained (new)
When GSSKEX hardening still leaves valid algorithms, the config now also writes GSSAPIAuthentication yes alongside GSSAPIKexAlgorithms. Previously only the algorithm list was written, leaving the GSSAPIAuthentication state ambiguous.

5. Removed || echo "" pipeline hack
The old || echo "" on the HARDENED_GSSKEX line was suppressing a non-zero exit from grep (no matches) in a set -e shell. The new GSSAPI guard makes this unnecessary.