### PR TITLE
LA-24113 Fix master.sh script with improved lightbeam port forward service health check

### DIFF
--- a/RHEL/master.sh
+++ b/RHEL/master.sh
@@ -1,8 +1,32 @@
 #!/usr/bin/env bash
+#
+# Sets up a Lightbeam Kubernetes control-plane node on RHEL (Docker, Kubernetes, Calico,
+# and the lightbeam.service systemd unit that port-forwards the Kong proxy on 80/443).
+#
+# Usage:
+#   sudo bash master.sh [--hostname=<host>]
+#
+#   --hostname=<host>  Optional. The Lightbeam endpoint hostname for this cluster (the
+#                       hostname Lightbeam is reached at).
 
 if [ "$EUID" -ne 0 ]; then
   echo "Please run as root."
   exit
+fi
+
+# Optional Lightbeam endpoint hostname for this cluster — see usage note above. Only
+# consumed downstream by lightbeam.sh's health check; capturing it here is the point.
+LB_HOSTNAME=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --hostname=*) LB_HOSTNAME="${1#*=}"; shift ;;
+    --hostname) LB_HOSTNAME="${2:-}"; shift 2 ;;
+    *) echo "Unrecognized argument: $1" >&2; exit 1 ;;
+  esac
+done
+if [[ -n "$LB_HOSTNAME" && ! "$LB_HOSTNAME" =~ ^[A-Za-z0-9.-]+$ ]]; then
+  echo "Invalid --hostname value: $LB_HOSTNAME" >&2
+  exit 1
 fi
 
 sudo yum update -y
@@ -253,6 +277,13 @@ PID2=$!
 
 /bin/systemd-notify --ready
 
+# LB_HOSTNAME_HEADER is filled in below (sed) from master.sh's --hostname flag, if given.
+LB_HOSTNAME_HEADER="__LB_HOSTNAME__"
+CURL_HOST_ARGS=()
+if [[ -n "$LB_HOSTNAME_HEADER" ]]; then
+  CURL_HOST_ARGS=(-H "Host: $LB_HOSTNAME_HEADER")
+fi
+
 while true; do
     FAIL=0
 
@@ -262,7 +293,7 @@ while true; do
     kill -0 $PID2
     if [[ $? -ne 0 ]]; then FAIL=1; fi
 
-    status_code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost/api/health)
+    status_code=$(curl -s -o /dev/null -w "%{http_code}" "${CURL_HOST_ARGS[@]}" http://localhost/api/health)
     echo "Lightbeam cluster health check: $status_code"
     if [[ $? -ne 0 || $status_code -ne 200 ]]; then FAIL=1; fi
 
@@ -271,6 +302,8 @@ while true; do
     sleep 1
 done
 EOF
+
+sed -i "s|__LB_HOSTNAME__|${LB_HOSTNAME}|" /usr/local/bin/lightbeam.sh
 
 echo "Script /usr/local/bin/lightbeam.sh has been created."
 chmod ugo+x /usr/local/bin/lightbeam.sh

--- a/Ubuntu/master.sh
+++ b/Ubuntu/master.sh
@@ -1,8 +1,32 @@
 #!/usr/bin/env bash
+#
+# Sets up a Lightbeam Kubernetes control-plane node on Ubuntu (Docker, Kubernetes, Calico,
+# and the lightbeam.service systemd unit that port-forwards the Kong proxy on 80/443).
+#
+# Usage:
+#   sudo bash master.sh [--hostname=<host>]
+#
+#   --hostname=<host>  Optional. The Lightbeam endpoint hostname for this cluster (the
+#                       hostname Lightbeam is reached at).
 
 if [ "$EUID" -ne 0 ]; then
   echo "Please run as root."
   exit
+fi
+
+# Optional Lightbeam endpoint hostname for this cluster — see usage note above. Only
+# consumed downstream by lightbeam.sh's health check; capturing it here is the point.
+LB_HOSTNAME=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --hostname=*) LB_HOSTNAME="${1#*=}"; shift ;;
+    --hostname) LB_HOSTNAME="${2:-}"; shift 2 ;;
+    *) echo "Unrecognized argument: $1" >&2; exit 1 ;;
+  esac
+done
+if [[ -n "$LB_HOSTNAME" && ! "$LB_HOSTNAME" =~ ^[A-Za-z0-9.-]+$ ]]; then
+  echo "Invalid --hostname value: $LB_HOSTNAME" >&2
+  exit 1
 fi
 
 TIMEOUT=300
@@ -410,12 +434,19 @@ PID=$!
 
 /bin/systemd-notify --ready
 
+# LB_HOSTNAME_HEADER is filled in below (sed) from master.sh's --hostname flag, if given.
+LB_HOSTNAME_HEADER="__LB_HOSTNAME__"
+CURL_HOST_ARGS=()
+if [[ -n "$LB_HOSTNAME_HEADER" ]]; then
+  CURL_HOST_ARGS=(-H "Host: $LB_HOSTNAME_HEADER")
+fi
+
 while(true); do
     FAIL=0
     kill -0 $PID
     if [[ $? -ne 0 ]]; then FAIL=1; fi
 
-    status_code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost/api/health)
+    status_code=$(curl -s -o /dev/null -w "%{http_code}" "${CURL_HOST_ARGS[@]}" http://localhost/api/health)
     curl_exit=$?
     echo "Lightbeam cluster health check: $status_code (curl exit: $curl_exit)"
     if [[ $curl_exit -ne 0 || ( $status_code -ne 200 && $status_code -ne 301 ) ]]; then
@@ -426,6 +457,7 @@ while(true); do
     sleep 1
 done
 EOF
+sed -i "s|__LB_HOSTNAME__|${LB_HOSTNAME}|" /usr/local/bin/lightbeam.sh
 chmod ugo+x /usr/local/bin/lightbeam.sh
 
 tee /etc/systemd/system/lightbeam.service > /dev/null <<'EOF'


### PR DESCRIPTION
Fixes issue of lightbeam service restarts
```
systemctl status lightbeam
● lightbeam.service - LightBeam Application
     Loaded: loaded (/etc/systemd/system/lightbeam.service; enabled; vendor preset: enabled)
     Active: active (running) since Tue 2026-07-21 04:14:34 UTC; 2s ago
   Main PID: 3405277 (bash)
      Tasks: 11 (limit: 9418)
     Memory: 14.7M
     CGroup: /system.slice/lightbeam.service
             ├─3405277 bash /usr/local/bin/lightbeam.sh
             ├─3405279 /usr/bin/kubectl port-forward service/kong-proxy -n lightbeam --address 0.0.0.0 80:80 443:443 --kubeconfig /root/.kube/config
             └─3405302 sleep 1

Jul 21 04:14:34 tbfyblbmaster systemd[1]: Starting LightBeam Application...
Jul 21 04:14:34 tbfyblbmaster systemd[1]: Started LightBeam Application.
Jul 21 04:14:34 tbfyblbmaster lightbeam.sh[3405277]: Lightbeam cluster health check: 000
Jul 21 04:14:34 tbfyblbmaster lightbeam.sh[3405279]: Forwarding from 0.0.0.0:80 -> 8000
Jul 21 04:14:34 tbfyblbmaster lightbeam.sh[3405279]: Forwarding from 0.0.0.0:443 -> 8443
Jul 21 04:14:35 tbfyblbmaster lightbeam.sh[3405279]: Handling connection for 80
Jul 21 04:14:35 tbfyblbmaster lightbeam.sh[3405277]: Lightbeam cluster health check: 404
Jul 21 04:14:36 tbfyblbmaster lightbeam.sh[3405279]: Handling connection for 80
Jul 21 04:14:36 tbfyblbmaster lightbeam.sh[3405277]: Lightbeam cluster health check: 404
root@tbfyblbmaster:~# systemctl status lightbeam
● lightbeam.service - LightBeam Application
     Loaded: loaded (/etc/systemd/system/lightbeam.service; enabled; vendor preset: enabled)
     Active: activating (start) since Tue 2026-07-21 04:15:00 UTC; 9ms ago
   Main PID: 3405748 (bash)
      Tasks: 9 (limit: 9418)
     Memory: 3.0M
     CGroup: /system.slice/lightbeam.service
             ├─3405748 bash /usr/local/bin/lightbeam.sh
             ├─3405749 /usr/bin/kubectl port-forward service/kong-proxy -n lightbeam --address 0.0.0.0 80:80 443:443 --kubeconfig /root/.kube/config
             └─3405750 /bin/systemd-notify --ready

Jul 21 04:15:00 tbfyblbmaster systemd[1]: Starting LightBeam Application...
Jul 21 04:15:00 tbfyblbmaster systemd[1]: Started LightBeam Application.
root@tbfyblbmaster:~# systemctl status lightbeam
● lightbeam.service - LightBeam Application
     Loaded: loaded (/etc/systemd/system/lightbeam.service; enabled; vendor preset: enabled)
     Active: activating (auto-restart) (Result: watchdog) since Tue 2026-07-21 04:15:19 UTC; 225ms ago
    Process: 3406003 ExecStart=/usr/local/bin/lightbeam.sh (code=dumped, signal=ABRT)
   Main PID: 3406003 (code=dumped, signal=ABRT)

```