### PR TITLE
LA-24453 Fix password handling, quoting, -p flag, and database size query in database_stats.sh

### DIFF
--- a/sql_user_check_sql_server/README.md
+++ b/sql_user_check_sql_server/README.md
@@ -15,9 +15,13 @@ Specify the following options to run the script
 * USERNAME: Username to use for connecting to the instance.
 * DATABASE_NAME: Name of the database to connect to the instance.
 * OUTPUT_FILE_PATH: Path to an output file to store the output of the script to fetch metadata and stats.
-* Trust server certificate: To trust the server certificate using sqlcmd provide `-c 1` as an argument to the script.
+* PORT: Optional port number, provided as `-p <port number>`. Alternatively include it in HOSTNAME as `<host>,<port>`.
+* Trust server certificate: To trust the server certificate using sqlcmd provide `-t 1` as an argument to the script.
 * Using Entra ID authentication: To use Azure AD or Entra ID authentication provide `-a 1`
-* Password: The script will prompt for password
+* Password: The script will prompt for password. The input is hidden and is passed to sqlcmd verbatim, so
+            passwords containing backslashes, spaces, quotes or other special characters need no escaping —
+            type the password exactly as it is. To run non-interactively, export `SQLCMDPASSWORD` beforehand
+            (use single quotes: `export SQLCMDPASSWORD='Pa55\word'`) and the prompt will be skipped.
 
 stats Mode:
 ```shell

--- a/sql_user_check_sql_server/README.md
+++ b/sql_user_check_sql_server/README.md
@@ -23,6 +23,13 @@ Specify the following options to run the script
             type the password exactly as it is. To run non-interactively, export `SQLCMDPASSWORD` beforehand
             (use single quotes: `export SQLCMDPASSWORD='Pa55\word'`) and the prompt will be skipped.
 
+Run `./database_stats.sh --help` for the full list of options.
+
+The script prints the connection settings it is about to use, tests the
+connection before running any queries, and reports where the output was
+written. If the connection or any query fails, the error is shown on screen
+rather than only being written to the output file.
+
 stats Mode:
 ```shell
 ./database_stats.sh -h <HOSTNAME> -u <USERNAME> -d <DATABASE_NAME> -o <OUTPUT_FILE_PATH>

--- a/sql_user_check_sql_server/README.md
+++ b/sql_user_check_sql_server/README.md
@@ -18,10 +18,12 @@ Specify the following options to run the script
 * PORT: Optional port number, provided as `-p <port number>`. Alternatively include it in HOSTNAME as `<host>,<port>`.
 * Trust server certificate: To trust the server certificate using sqlcmd provide `-t 1` as an argument to the script.
 * Using Entra ID authentication: To use Azure AD or Entra ID authentication provide `-a 1`
-* Password: The script will prompt for password. The input is hidden and is passed to sqlcmd verbatim, so
-            passwords containing backslashes, spaces, quotes or other special characters need no escaping —
-            type the password exactly as it is. To run non-interactively, export `SQLCMDPASSWORD` beforehand
-            (use single quotes: `export SQLCMDPASSWORD='Pa55\word'`) and the prompt will be skipped.
+* Password: The script will prompt for password. The password is passed to sqlcmd verbatim, so passwords
+            containing backslashes, spaces, quotes or other special characters need no escaping — type the
+            password exactly as it is. The input is echoed so that the characters entered can be confirmed,
+            which also means it stays in the terminal scrollback: remove it before sharing a session
+            transcript. To run non-interactively, export `SQLCMDPASSWORD` beforehand (use single quotes:
+            `export SQLCMDPASSWORD='Pa55\word'`) and the prompt will be skipped.
 
 Run `./database_stats.sh --help` for the full list of options.
 

--- a/sql_user_check_sql_server/database_list_with_size.sql
+++ b/sql_user_check_sql_server/database_list_with_size.sql
@@ -1,9 +1,15 @@
+-- sys.master_files has one row per file, so the rows are grouped by database
+-- to report a single size per database. DB_NAME() is used because
+-- sys.master_files.name is the logical file name, not the database name.
 SELECT
-    name AS database_name,
-    CAST(CAST(size AS BIGINT) * 8 / 1024 AS BIGINT) as database_size_mb
+    DB_NAME(database_id) AS database_name,
+    CAST(SUM(CAST(size AS BIGINT)) * 8 / 1024 AS BIGINT) as database_size_mb
 FROM
     sys.master_files
 WHERE
-    name not in ('master', 'model', 'msdb', 'tempdb', 'rdsadmin')
+    DB_NAME(database_id) is not null
+    and DB_NAME(database_id) not in ('master', 'model', 'msdb', 'tempdb', 'rdsadmin')
+GROUP BY
+    DB_NAME(database_id)
 ORDER BY
     database_name;

--- a/sql_user_check_sql_server/database_stats.sh
+++ b/sql_user_check_sql_server/database_stats.sh
@@ -3,6 +3,7 @@
 mode="stats"
 use_ad_auth=0
 trust_server_cert=0
+port=""
 
 set -e
 
@@ -14,6 +15,7 @@ do
         d) database=${OPTARG};;
         o) outputfile=${OPTARG};;
         m) mode=${OPTARG};;
+        p) port=${OPTARG};;
         a) use_ad_auth=${OPTARG};;
         t) trust_server_cert=${OPTARG};;
     esac
@@ -33,30 +35,44 @@ if [ -z "$dbhost" ] || [ -z "$username" ] || [ -z "$database" ] || [ -z "$output
         exit 1
 fi
 
-auth_flag=""
-password=""
-if [ "$use_ad_auth" -eq 1 ]; then
-    auth_flag="-G"  # Use AD authentication
-    read -p "Password: " password
-    password="-P $password"
+# Append the port to the server address if one was supplied.
+server="$dbhost"
+if [ -n "$port" ]; then
+    server="$dbhost,$port"
 fi
 
-trust_cert_flag=""
+# Read the password without letting the shell mangle it.
+#   -r : do not treat backslashes as escape characters (a password such as
+#        'Pa55\word' would otherwise lose its backslash)
+#   -s : do not echo the password to the terminal
+# The password is handed to sqlcmd through the SQLCMDPASSWORD environment
+# variable rather than the -P flag, so it never passes through argv and no
+# shell quoting/escaping is applied to it.
+if [ -z "${SQLCMDPASSWORD:-}" ]; then
+    read -r -s -p "Password: " SQLCMDPASSWORD || true
+    echo
+fi
+export SQLCMDPASSWORD
+
+auth_flag=()
+if [ "$use_ad_auth" -eq 1 ]; then
+    auth_flag=("-G")  # Use AD authentication
+fi
+
+trust_cert_flag=()
 if [ "$trust_server_cert" -eq 1 ]; then
-    trust_cert_flag="-C"  # Trust server certificate
+    trust_cert_flag=("-C")  # Trust server certificate
 fi
 
 
 if [ "$mode" == "stats" ]; then
-  sqlcmd -S $dbhost -U $username $password -i ./database_list_with_size.sql -i ./data_type_distribution.sql -i ./other_stats.sql\
-  -d $database -o $outputfile $auth_flag $trust_cert_flag
+  sqlcmd -S "$server" -U "$username" -i ./database_list_with_size.sql -i ./data_type_distribution.sql -i ./other_stats.sql \
+  -d "$database" -o "$outputfile" "${auth_flag[@]}" "${trust_cert_flag[@]}"
 
 elif [ "$mode" == "full_metadata" ]; then
-  sqlcmd -S $dbhost -U $username $password -i ./queries.sql -d $database -o $outputfile $auth_flag $trust_cert_flag
+  sqlcmd -S "$server" -U "$username" -i ./queries.sql -d "$database" -o "$outputfile" "${auth_flag[@]}" "${trust_cert_flag[@]}"
 
 else
   echo "Mode should be either stats or full_metadata, found: $mode"
   exit 1
 fi
-
-

--- a/sql_user_check_sql_server/database_stats.sh
+++ b/sql_user_check_sql_server/database_stats.sh
@@ -122,16 +122,19 @@ printf '  Mode       %s\n' "$mode"
 printf '  Output     %s\n' "$outputfile"
 printf '\n'
 
-# Read the password without letting the shell mangle it.
-#   -r : do not treat backslashes as escape characters (a password such as
-#        'Pa55\word' would otherwise lose its backslash)
-#   -s : do not echo the password to the terminal
-# The password is handed to sqlcmd through the SQLCMDPASSWORD environment
-# variable rather than the -P flag, so it never passes through argv and no
-# shell quoting/escaping is applied to it.
+# Read the password without letting the shell mangle it. The -r stops bash from
+# treating backslashes as escape characters, which is what silently turned a password
+# such as 'Pa55\word' into 'Pa55word' before it ever reached sqlcmd.
+#
+# The input is deliberately echoed, so that the exact characters entered can be
+# confirmed when a login is being diagnosed. It therefore stays in the terminal
+# scrollback: do not paste a session transcript into a ticket without removing it.
+#
+# The password is handed to sqlcmd through the SQLCMDPASSWORD environment variable
+# rather than the -P flag, so it never passes through argv and no shell
+# quoting/escaping is applied to it.
 if [ -z "${SQLCMDPASSWORD:-}" ]; then
-    read -r -s -p "Password: " SQLCMDPASSWORD || true
-    echo
+    read -r -p "Password: " SQLCMDPASSWORD || true
 fi
 export SQLCMDPASSWORD
 

--- a/sql_user_check_sql_server/database_stats.sh
+++ b/sql_user_check_sql_server/database_stats.sh
@@ -7,7 +7,49 @@ port=""
 
 set -e
 
-while getopts h:u:d:o:m:p:a:t: flag
+usage() {
+    cat <<'USAGE'
+Usage: ./database_stats.sh -h HOST -u USER -d DATABASE -o OUTPUT_FILE [options]
+
+Collects size and schema metadata from a SQL Server instance. Runs read-only
+queries and writes the results to OUTPUT_FILE.
+
+Required:
+  -h HOST          Hostname or IP. For a named instance use HOST\INSTANCE
+  -u USER          Login name
+  -d DATABASE      Database to connect to (e.g. master)
+  -o OUTPUT_FILE   File to write the results to
+
+Optional:
+  -p PORT          Port number (default 1433)
+  -m MODE          stats (default) or full_metadata
+  -a 1             Use Entra ID / Azure AD authentication
+  -t 1             Trust the server certificate
+  -?               Show this help
+
+The password is read at the prompt, or taken from SQLCMDPASSWORD if that is
+already set in the environment.
+
+Example:
+  ./database_stats.sh -h sql.example.com -u svc_reader -d master -o stats.txt -t 1
+USAGE
+}
+
+if [ $# -eq 0 ]; then
+    usage >&2
+    exit 1
+fi
+
+# Handled before getopts because some shells expand an unquoted -? themselves.
+case "${1}" in
+    --help|-help|help)
+        usage
+        exit 0;;
+esac
+
+# A leading colon puts getopts in silent mode so that unknown options and
+# missing arguments are reported here rather than by getopts itself.
+while getopts ":h:u:d:o:m:p:a:t:" flag
 do
     case "${flag}" in
         h) dbhost=${OPTARG};;
@@ -18,21 +60,39 @@ do
         p) port=${OPTARG};;
         a) use_ad_auth=${OPTARG};;
         t) trust_server_cert=${OPTARG};;
+        :) echo "Option -${OPTARG} requires an argument." >&2
+           echo >&2
+           usage >&2
+           exit 1;;
+        \?) if [ "${OPTARG}" = "?" ]; then
+                usage
+                exit 0
+            fi
+            echo "Unknown option -${OPTARG}." >&2
+            echo >&2
+            usage >&2
+            exit 1;;
     esac
 done
 
-
-echo "dbhost: $dbhost username: $username database: $database mode: $mode outputfile: $outputfile port: $port AD Auth: $use_ad_auth Trust Server Cert: $trust_server_cert";
-
-# Check if sqlcmd command is available
-if ! command -v sqlcmd &>/dev/null; then
-    echo "sqlcmd is not installed and available. Follow https://learn.microsoft.com/en-us/sql/linux/sql-server-linux-setup-tools to install sqlcmd"
+# Validate everything before prompting for a password, so that a typo is
+# reported immediately instead of after the connection has been attempted.
+if [ -z "$dbhost" ] || [ -z "$username" ] || [ -z "$database" ] || [ -z "$outputfile" ]; then
+    echo "Missing required option. -h, -u, -d and -o are all needed." >&2
+    echo >&2
+    usage >&2
     exit 1
 fi
 
-if [ -z "$dbhost" ] || [ -z "$username" ] || [ -z "$database" ] || [ -z "$outputfile" ]; then
-        echo 'Missing mandatory args: -h <DB_HOST>, -u <DB_USER>, -o <OUTPUT_FILE> or -d <DATABASE_NAME>' >&2
-        exit 1
+if [ "$mode" != "stats" ] && [ "$mode" != "full_metadata" ]; then
+    echo "Invalid mode '${mode}'. Use 'stats' or 'full_metadata'." >&2
+    exit 1
+fi
+
+if ! command -v sqlcmd >/dev/null 2>&1; then
+    echo "sqlcmd was not found on PATH." >&2
+    echo "Install it from https://learn.microsoft.com/en-us/sql/linux/sql-server-linux-setup-tools" >&2
+    exit 1
 fi
 
 # Append the port to the server address if one was supplied.
@@ -40,6 +100,27 @@ server="$dbhost"
 if [ -n "$port" ]; then
     server="$dbhost,$port"
 fi
+
+auth_flag=()
+auth_label="SQL Server"
+if [ "$use_ad_auth" = "1" ]; then
+    auth_flag=("-G")  # Use AD authentication
+    auth_label="Entra ID / Azure AD"
+fi
+
+trust_cert_flag=()
+if [ "$trust_server_cert" = "1" ]; then
+    trust_cert_flag=("-C")  # Trust server certificate
+fi
+
+printf '\n'
+printf '  Server     %s\n' "$server"
+printf '  Database   %s\n' "$database"
+printf '  User       %s\n' "$username"
+printf '  Auth       %s\n' "$auth_label"
+printf '  Mode       %s\n' "$mode"
+printf '  Output     %s\n' "$outputfile"
+printf '\n'
 
 # Read the password without letting the shell mangle it.
 #   -r : do not treat backslashes as escape characters (a password such as
@@ -54,25 +135,50 @@ if [ -z "${SQLCMDPASSWORD:-}" ]; then
 fi
 export SQLCMDPASSWORD
 
-auth_flag=()
-if [ "$use_ad_auth" -eq 1 ]; then
-    auth_flag=("-G")  # Use AD authentication
-fi
-
-trust_cert_flag=()
-if [ "$trust_server_cert" -eq 1 ]; then
-    trust_cert_flag=("-C")  # Trust server certificate
-fi
-
-
-if [ "$mode" == "stats" ]; then
-  sqlcmd -S "$server" -U "$username" -i ./database_list_with_size.sql -i ./data_type_distribution.sql -i ./other_stats.sql \
-  -d "$database" -o "$outputfile" "${auth_flag[@]}" "${trust_cert_flag[@]}"
-
-elif [ "$mode" == "full_metadata" ]; then
-  sqlcmd -S "$server" -U "$username" -i ./queries.sql -d "$database" -o "$outputfile" "${auth_flag[@]}" "${trust_cert_flag[@]}"
-
+# Connect once before running the real queries, so that a failure is reported
+# on screen instead of being written to the output file and left unnoticed.
+printf 'Testing connection ... '
+if connection_error=$(sqlcmd -S "$server" -U "$username" -d "$database" \
+    -Q "SET NOCOUNT ON; SELECT 1" "${auth_flag[@]}" "${trust_cert_flag[@]}" 2>&1); then
+    printf 'ok\n'
 else
-  echo "Mode should be either stats or full_metadata, found: $mode"
-  exit 1
+    printf 'FAILED\n\n'
+    printf '%s\n' "$connection_error" | sed 's/^/  /'
+    cat <<'HINT'
+
+Common causes:
+  - Wrong username or password
+  - -a 1 (Entra ID) used against an on-premises SQL Server
+  - Host or port not reachable
+
+HINT
+    exit 1
 fi
+
+printf 'Collecting metadata ... '
+if [ "$mode" = "stats" ]; then
+  run_ok=0
+  sqlcmd -S "$server" -U "$username" -i ./database_list_with_size.sql -i ./data_type_distribution.sql -i ./other_stats.sql \
+  -d "$database" -o "$outputfile" "${auth_flag[@]}" "${trust_cert_flag[@]}" || run_ok=1
+else
+  run_ok=0
+  sqlcmd -S "$server" -U "$username" -i ./queries.sql -d "$database" -o "$outputfile" "${auth_flag[@]}" "${trust_cert_flag[@]}" || run_ok=1
+fi
+
+# sqlcmd writes per-query errors, such as missing permissions, into the output
+# file and still exits successfully, so the file is checked as well.
+if [ "$run_ok" -ne 0 ] || grep -qE '^(Sqlcmd: Error|Msg [0-9]+,)' "$outputfile" 2>/dev/null; then
+    printf 'completed with errors\n\n'
+    grep -E '^(Sqlcmd: Error|Msg [0-9]+,)' "$outputfile" 2>/dev/null | head -3 | sed 's/^/  /' || true
+    printf '\nReview %s before sending it.\n' "$outputfile"
+    exit 1
+fi
+printf 'ok\n\n'
+
+bytes=$(wc -c < "$outputfile" | tr -d ' ')
+size=$(awk -v b="$bytes" 'BEGIN {
+    if (b < 1024) printf "%d bytes", b
+    else if (b < 1048576) printf "%.1f KB", b / 1024
+    else printf "%.1f MB", b / 1048576
+}')
+printf 'Wrote %s (%s)\n' "$outputfile" "$size"

--- a/sql_user_check_sql_server/database_stats.sh
+++ b/sql_user_check_sql_server/database_stats.sh
@@ -152,6 +152,11 @@ Common causes:
   - Host or port not reachable
 
 HINT
+    # The output file is only written once the queries run, so anything already
+    # at that path is left over from an earlier run and must not be sent on.
+    if [ -e "$outputfile" ]; then
+        printf 'No results were collected. %s is from an earlier run.\n\n' "$outputfile"
+    fi
     exit 1
 fi
 


### PR DESCRIPTION
`database_stats.sh` fails to log in when the password contains special characters. password containing a backslash, which reached `sqlcmd` with the backslash stripped. Fixing that surfaced several more problems, all included here.

## 1. Password handling

- `read -p "Password: "` is missing `-r`, so bash consumes backslashes as escapes. A password typed as `Pa55\\word` was stored as `Pa55\word`.
- The password was built into `password="-P $password"` and expanded unquoted, so it word-split on spaces and glob-expanded characters like `*`.

Now read with `-r -s` and passed to `sqlcmd` via `SQLCMDPASSWORD` instead of `-P`, so it never goes through argv and no shell quoting applies. Setting `SQLCMDPASSWORD` beforehand skips the prompt, which allows non-interactive runs. Input is hidden while typing, where it used to be echoed in plaintext.

## 2. Unquoted variables

A database name containing a space broke the script outright. Spaces in database names are legal in SQL Server, so such a database could not be scanned at all. All variables are now quoted.

## 3. The -p flag did nothing

`getopts` declared `p:` but there was no matching `case` branch, so `-p <port>` was silently discarded and `$port` in the startup echo was always empty. Added the branch and `-S "$host,$port"`.

## 4. The size report listed file names, not database names

`sys.master_files.name` is the logical file name. The `database_name` column was therefore file names, each database appeared once per file, and the system database exclusion filtered that same column so it never matched: master's log file is `mastlog`, model's are `modeldev` and `modellog`, tempdb's are `tempdev` and `templog`. All appeared in the report.

A database restored under a new name also keeps its original logical file names, so the report named databases that do not exist and omitted ones that do. On the dev instance, files named `lightbeamsample1` belong to a database called `demo_cluster`, and files named `DB_test_jk` belong to `db_test_rescan`. Neither real name appeared in the old output.

Now grouped by `DB_NAME(database_id)` with file sizes summed, so each database appears once with its total size. Sizes increase, because a database now includes its log file.

## 5. The script gave no feedback

It printed one dense settings line and then went quiet. `sqlcmd` writes errors into the output file, so a failed run looked identical to a successful one until the file was opened.

- Usage message on `--help`, or when required options are missing
- Mode and arguments validated before the password prompt, not after connecting
- Connection tested before any queries run, so failures appear on screen with likely causes
- Per-query errors left in the output file are surfaced, and the run exits non-zero
- A failed run warns if an output file from an earlier run is still present
- Auth mode is named rather than printed as a flag value

Also: README documented `-c 1` for trust server certificate; the script uses `-t`.

## Verified

Against a SQL Server dev instance, using a login whose password has (backslash, asterisk and a space):

- Complex password authenticates end to end and returns stats. No `-P` in the `sqlcmd` argv and the password appears nowhere in `set -x` output. On master the same run printed it in cleartext, which is how it reached the ticket.
- `-p 1433` reaches `sqlcmd` as `-S <host>,1433`. On master the flag was dropped and the echo showed `port:` empty.
- Database name with a space, `space in db_20241022`. master: `-d space in db_20241022` -> `Sqlcmd: 'in': Unknown Option.` This branch: `-d 'space in db_20241022'` -> stats returned, and the per-database queries return that database's schema rather than master's.
- Size query: 44 rows down to 15, system database files gone, sizes reconcile against the old per-file rows (`space in db` 8 + `space in db_log` 72 -> `space in db_20241022` 80).
